### PR TITLE
Fix SM-2 citation year and package URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 **Spaced-repetition study tool along the Ebbinghaus forgetting curve (SM-2), with a CLI and web UI**
 
 ![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)
+[![CI](https://github.com/jumincho/ebbinghaus-reviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/jumincho/ebbinghaus-reviewer/actions/workflows/ci.yml)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-72%20passing-brightgreen)
 ![Algorithm](https://img.shields.io/badge/algorithm-SM--2-512BD4)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 **Spaced-repetition study tool along the Ebbinghaus forgetting curve (SM-2)**
 
 ![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)
+[![CI](https://github.com/jumincho/ebbinghaus-reviewer/actions/workflows/ci.yml/badge.svg)](https://github.com/jumincho/ebbinghaus-reviewer/actions/workflows/ci.yml)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-72%20passing-brightgreen)
 ![Algorithm](https://img.shields.io/badge/algorithm-SM--2-512BD4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ dev = [
 ebbinghaus = "ebbinghaus_reviewer.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/properly59/ebbinghaus-reviewer"
-Repository = "https://github.com/properly59/ebbinghaus-reviewer"
+Homepage = "https://github.com/jumincho/ebbinghaus-reviewer"
+Repository = "https://github.com/jumincho/ebbinghaus-reviewer"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ebbinghaus_reviewer"]

--- a/src/ebbinghaus_reviewer/algorithm.py
+++ b/src/ebbinghaus_reviewer/algorithm.py
@@ -1,4 +1,4 @@
-"""Pure SM-2 spaced-repetition algorithm (Wozniak, 1985).
+"""Pure SM-2 spaced-repetition algorithm (Wozniak, 1990).
 
 This module is the heart of the spaced-repetition / Ebbinghaus logic. It is
 deliberately free of any I/O, persistence, or clock access: every function is


### PR DESCRIPTION
A deep, line-by-line review of the whole repo (read every source file, ran the suite, ran the linters, and diffed the README demo against real CLI output). The code is genuinely solid — pure SM-2 done by the book, clean storage layer, lazy-imported web UI, first-party CI. I deliberately did **not** churn working code; here are the two real defects found, plus a small badge.

## Real fixes
- **Wrong citation year.** `algorithm.py`'s module docstring called SM-2 *"(Wozniak, 1985)"*. 1985 is the paper-and-pencil SM-0 method; SM-2 is 1987, published 1990 — exactly what the reference link, `docs/algorithm.md` ("1987, published 1990"), and both READMEs already say. Docstring made consistent (1990).
- **Package URLs point at the wrong account.** `pyproject.toml` had `Homepage`/`Repository` = `github.com/properly59/...`, but the repo lives at `github.com/jumincho/ebbinghaus-reviewer`. Corrected.

## Polish
- READMEs (KO/EN/ZH): added a live **CI** badge next to the static "72 passing" count.

## Verification
- `ruff check .` ✅  ·  `mypy src` ✅  ·  `pytest` ✅ (72 passed)
- Ran the CLI in a scratch DB; the `add` / `today` / `stats` output matches the README demo block exactly.

https://claude.ai/code/session_011AjsUFiGcGPH71NuxTbHib

---
_Generated by [Claude Code](https://claude.ai/code/session_011AjsUFiGcGPH71NuxTbHib)_